### PR TITLE
Add minimal full-stack example

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import Depends, FastAPI, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import ForeignKey, create_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker, Session
+
+DATABASE_URL = "sqlite:///./app.db"
+
+engine = create_engine(DATABASE_URL, echo=True, future=True)
+SessionLocal = sessionmaker(bind=engine, future=True)
+
+class Base(DeclarativeBase):
+    pass
+
+class Material(Base):
+    __tablename__ = "materials"
+    Material_ID: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    Name: Mapped[str]
+    GWP: Mapped[int]
+    components: Mapped[List["Component"]] = relationship(back_populates="material")
+
+class Component(Base):
+    __tablename__ = "components"
+    ID: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    Name: Mapped[str]
+    Ebene: Mapped[int]
+    Parent_ID: Mapped[Optional[int]] = mapped_column(ForeignKey("components.ID"), nullable=True)
+    Atomar: Mapped[bool]
+    Gewicht: Mapped[int]  # grams
+    Komponente_Wiederverwendbar: Mapped[bool]
+    Verbindungstyp: Mapped[str]
+    Material_ID: Mapped[int] = mapped_column(ForeignKey("materials.Material_ID"))
+
+    parent: Mapped[Optional["Component"]] = relationship(remote_side=[ID], backref="children")
+    material: Mapped[Material] = relationship(back_populates="components")
+
+# Pydantic schemas
+class MaterialCreate(BaseModel):
+    Name: str
+    GWP: int
+
+class MaterialRead(MaterialCreate):
+    Material_ID: int
+
+    class Config:
+        orm_mode = True
+
+class ComponentCreate(BaseModel):
+    Name: str
+    Ebene: int
+    Parent_ID: Optional[int] = None
+    Atomar: bool
+    Gewicht: int
+    Komponente_Wiederverwendbar: bool
+    Verbindungstyp: str
+    Material_ID: int
+
+class ComponentRead(ComponentCreate):
+    ID: int
+
+    class Config:
+        orm_mode = True
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app = FastAPI()
+
+@app.on_event("startup")
+def on_startup() -> None:
+    Base.metadata.create_all(bind=engine)
+
+@app.post("/materials/", response_model=MaterialRead)
+def create_material(material: MaterialCreate, db: Session = Depends(get_db)):
+    db_obj = Material(**material.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+@app.get("/materials/", response_model=List[MaterialRead])
+def read_materials(db: Session = Depends(get_db)):
+    return db.query(Material).all()
+
+@app.post("/components/", response_model=ComponentRead)
+def create_component(component: ComponentCreate, db: Session = Depends(get_db)):
+    db_obj = Component(**component.dict())
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+@app.get("/components/", response_model=List[ComponentRead])
+def read_components(db: Session = Depends(get_db)):
+    return db.query(Component).all()
+

--- a/frontend.py
+++ b/frontend.py
@@ -1,0 +1,50 @@
+import json
+import requests
+import typer
+
+API_URL = "http://localhost:8000"
+
+app = typer.Typer(help="Simple CLI frontend for the FastAPI backend")
+
+@app.command()
+def list_materials():
+    resp = requests.get(f"{API_URL}/materials/")
+    typer.echo(json.dumps(resp.json(), indent=2))
+
+@app.command()
+def add_material(name: str, gwp: int):
+    payload = {"Name": name, "GWP": gwp}
+    resp = requests.post(f"{API_URL}/materials/", json=payload)
+    typer.echo(json.dumps(resp.json(), indent=2))
+
+@app.command()
+def list_components():
+    resp = requests.get(f"{API_URL}/components/")
+    typer.echo(json.dumps(resp.json(), indent=2))
+
+@app.command()
+def add_component(
+    name: str,
+    ebene: int,
+    material_id: int,
+    parent_id: int | None = None,
+    atomar: bool = True,
+    gewicht: int = 0,
+    wiederverwendbar: bool = True,
+    verbindungstyp: str = "unknown",
+):
+    payload = {
+        "Name": name,
+        "Ebene": ebene,
+        "Parent_ID": parent_id,
+        "Atomar": atomar,
+        "Gewicht": gewicht,
+        "Komponente_Wiederverwendbar": wiederverwendbar,
+        "Verbindungstyp": verbindungstyp,
+        "Material_ID": material_id,
+    }
+    resp = requests.post(f"{API_URL}/components/", json=payload)
+    typer.echo(json.dumps(resp.json(), indent=2))
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Summary
- create `backend.py` implementing a FastAPI server with SQLAlchemy models
- create `frontend.py` providing a Typer CLI that consumes the API

## Testing
- `python3 -m py_compile backend.py frontend.py`
- `pytest -q`
- `python3 -m pip install fastapi==0.110.0 sqlalchemy==2.0.29 uvicorn==0.29.0 requests==2.31.0 typer==0.12.3 --quiet`

------
https://chatgpt.com/codex/tasks/task_b_685d4a7d0180832893b4e78f1493102b