### PR TITLE
Remove unused HTTPException import

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI
 from pydantic import BaseModel
 from sqlalchemy import ForeignKey, create_engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker, Session


### PR DESCRIPTION
## Summary
- clean up `backend.py` by removing an unused FastAPI import

## Testing
- `flake8 backend.py frontend.py --select=F401`


------
https://chatgpt.com/codex/tasks/task_b_685d525ad4c48328aa8524ade5ac3813