### PR TITLE
Add README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# DIMOP_2.2
+
+This repository contains a simple example with a FastAPI backend and a Streamlit
+frontend. It demonstrates how to build a minimal full‑stack application in
+Python.
+
+## Requirements
+
+- **Python 3.10+**
+- `fastapi`, `sqlalchemy`, `uvicorn`, `streamlit`
+
+Install the dependencies with:
+
+```bash
+python3 -m pip install fastapi sqlalchemy uvicorn streamlit
+```
+
+## Running the backend
+
+Start the API server with Uvicorn. The database `app.db` will be created
+automatically in the repository root.
+
+```bash
+uvicorn backend:app --reload
+```
+
+## Starting the Streamlit frontend
+
+Launch the web interface once the backend is running:
+
+```bash
+streamlit run frontend.py
+```
+
+## Packaging with PyInstaller
+
+You can create a standalone executable of either entry point using
+[PyInstaller](https://pyinstaller.org/). First install it:
+
+```bash
+python3 -m pip install pyinstaller
+```
+
+Then build the executable with the `--onefile` flag. For example, to package the
+Streamlit frontend run:
+
+```bash
+pyinstaller --onefile frontend.py
+```
+
+The resulting binary is placed inside the `dist` directory. Execute it from
+there so that any bundled assets can be found correctly.


### PR DESCRIPTION
## Summary
- document the required Python version and dependencies
- provide commands for starting the FastAPI backend and Streamlit frontend
- explain how to package the app with PyInstaller

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(runs only if there are Python files)*

------
https://chatgpt.com/codex/tasks/task_b_685d5d39b4f88328bb58634bf7df83e9