### PR TITLE
Document backend URL config for Streamlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ Launch the web interface once the backend is running:
 streamlit run frontend.py
 ```
 
+The Streamlit app looks for the API at `http://localhost:8000` by default. If
+your backend is running at a different address you can override the URL in two
+ways:
+
+1. Create a `.streamlit/secrets.toml` file in the project root containing:
+
+   ```toml
+   BACKEND_URL = "http://localhost:8000"
+   ```
+
+2. Or set the environment variable before launching Streamlit:
+
+   ```bash
+   export BACKEND_URL="http://localhost:8000"
+   streamlit run frontend.py
+   ```
+
 ## Packaging with PyInstaller
 
 You can create a standalone executable of either entry point using

--- a/frontend.py
+++ b/frontend.py
@@ -1,7 +1,8 @@
+import os
 import streamlit as st
 import requests
 
-BACKEND_URL = st.secrets.get("BACKEND_URL", "http://localhost:8000")
+BACKEND_URL = os.getenv("BACKEND_URL", st.secrets.get("BACKEND_URL", "http://localhost:8000"))
 
 # TODO: add Streamlit-based login and store the returned token
 # auth_token = st.session_state.get("token")


### PR DESCRIPTION
## Summary
- explain how to configure `BACKEND_URL` in README
- allow overriding `BACKEND_URL` via environment variable

## Testing
- `python -m py_compile backend.py frontend.py`

------
https://chatgpt.com/codex/tasks/task_b_685d6484f9788328887541dd0c88978d