### PR TITLE
Add requirements file and update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Python.
 ## Requirements
 
 - **Python 3.10+**
-- `fastapi`, `sqlalchemy`, `uvicorn`, `streamlit`
+- `fastapi`, `sqlalchemy`, `uvicorn`, `streamlit`, `requests`
 
 Install the dependencies with:
 
 ```bash
-python3 -m pip install fastapi sqlalchemy uvicorn streamlit
+pip install -r requirements.txt
 ```
 
 ## Running the backend

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlalchemy
+streamlit
+requests


### PR DESCRIPTION
## Summary
- add `requirements.txt` with backend/frontend requirements
- update README install instructions to use requirements file

## Testing
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_685d648285ac83289be3a65f012ea99b