### PR TITLE
Add sample tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,52 @@
+# flake8: noqa
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.orm import sessionmaker
+import backend
+import pytest
+
+
+@pytest.fixture
+def client():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False
+    )
+    backend.engine = engine
+    backend.SessionLocal = TestingSessionLocal
+    backend.Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    backend.app.dependency_overrides[backend.get_db] = override_get_db
+    with TestClient(backend.app) as c:
+        yield c
+    backend.app.dependency_overrides.clear()
+
+
+def test_create_and_read_materials(client):
+    resp = client.post("/materials", json={"name": "Steel"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Steel"
+
+    resp = client.get("/materials")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["name"] == "Steel"

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -1,0 +1,32 @@
+# flake8: noqa
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+import pytest
+from backend import compute_component_score, Component, Material
+
+
+def test_compute_component_score_atomic():
+    mat = Material(id=1, name="Steel", co2_value=2.0)
+    comp = Component(id=1, is_atomic=True, weight=3.0, material=mat)
+    score = compute_component_score(comp, None)
+    assert score == 6.0
+
+
+def test_compute_component_score_hierarchy():
+    mat = Material(id=1, name="Steel", co2_value=5.0)
+    child = Component(id=2, name="child", is_atomic=True, weight=1.0, material=mat)
+    root = Component(
+        id=3,
+        name="root",
+        is_atomic=False,
+        weight=2.0,
+        reusable=False,
+        connection_type="screwed",
+    )
+    root.children.append(child)
+    child.parent = root
+    score = compute_component_score(root, None)
+    assert pytest.approx(score) == 9.5


### PR DESCRIPTION
## Summary
- add tests for compute_component_score
- add API integration test using FastAPI TestClient

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863b8f050588332ace44557f4b6dc47