### PR TITLE
Add httpx-based API tests and dev tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,26 @@ pyinstaller --onefile frontend.py
 The resulting binary is placed inside the `dist` directory. Execute it from
 there so that any bundled assets can be found correctly.
 
+## Development
+
+Install the development dependencies using:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Run the test suite with:
+
+```bash
+pytest
+```
+
+Check the code style using the linter:
+
+```bash
+ruff check .
+```
+
 ## Future authentication integration
 
 The example application intentionally omits user authentication to keep the

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+httpx
+ruff


### PR DESCRIPTION
## Summary
- update tests to use httpx `AsyncClient`
- add `requirements-dev.txt` with pytest, httpx and ruff
- document dev workflow in README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863c0acfdb08332bffedff45d71cf56