### PR TITLE
Ensure CO₂ column added on startup

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -10,6 +10,8 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     Boolean,
+    inspect,
+    text,
 )
 from sqlalchemy.orm import (
     declarative_base,
@@ -204,6 +206,14 @@ app = FastAPI()
 
 @app.on_event("startup")
 def on_startup():
+    inspector = inspect(engine)
+    if "materials" in inspector.get_table_names():
+        cols = [c["name"] for c in inspector.get_columns("materials")]
+        if "co2_value" not in cols:
+            with engine.connect() as conn:
+                conn.execute(
+                    text("ALTER TABLE materials ADD COLUMN co2_value FLOAT")
+                )
     Base.metadata.create_all(bind=engine)
 
 


### PR DESCRIPTION
## Summary
- inspect database schema on startup and add `co2_value` column if missing
- adjust API test fixture to create an old-style materials table and run startup

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6863c919731c83329c58ddbc8ea6c32d