### PR TITLE
Add startup column migration test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,6 +47,45 @@ async def async_client():
     backend.app.dependency_overrides.clear()
 
 
+@pytest.fixture
+async def async_client_missing_columns():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE materials (id INTEGER PRIMARY KEY, name VARCHAR, description VARCHAR)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE TABLE components (id INTEGER PRIMARY KEY, name VARCHAR, material_id INTEGER)"
+            )
+        )
+    TestingSessionLocal = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False
+    )
+    backend.engine = engine
+    backend.SessionLocal = TestingSessionLocal
+    backend.on_startup()
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    backend.app.dependency_overrides[backend.get_db] = override_get_db
+    transport = ASGITransport(app=backend.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    backend.app.dependency_overrides.clear()
+
+
 @pytest.mark.anyio("asyncio")
 async def test_create_and_read_materials(async_client):
     login = await async_client.post(
@@ -68,3 +107,31 @@ async def test_create_and_read_materials(async_client):
     items = resp.json()
     assert len(items) == 1
     assert items[0]["name"] == "Steel"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_startup_adds_component_columns(async_client_missing_columns):
+    login = await async_client_missing_columns.post(
+        "/token",
+        data={"username": "admin", "password": "secret"},
+    )
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = await async_client_missing_columns.post(
+        "/materials", json={"name": "Steel"}, headers=headers
+    )
+    material_id = resp.json()["id"]
+
+    resp = await async_client_missing_columns.post(
+        "/components",
+        json={"name": "Root", "material_id": material_id},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "level" in data
+
+    inspector = backend.inspect(backend.engine)
+    cols = [c["name"] for c in inspector.get_columns("components")]
+    assert "level" in cols


### PR DESCRIPTION
## Summary
- extend the API test suite
- add fixture creating a `components` table without new columns
- verify that `backend.on_startup()` adds the `level` column and allows component creation

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_6863cf0164ec833298969411f1e15041