### PR TITLE
Handle numeric connection_type

### DIFF
--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -24,7 +24,7 @@ def test_compute_component_score_hierarchy():
         is_atomic=False,
         weight=2.0,
         reusable=False,
-        connection_type="screwed",
+        connection_type=1,
     )
     root.children.append(child)
     child.parent = root


### PR DESCRIPTION
## Summary
- store `connection_type` as an integer
- adjust pydantic models and DB migration
- update component scoring logic for numeric factor
- adapt compute tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871205444e48328a3e6091ef239efee