### PR TITLE
Compute recursive component weights

### DIFF
--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -5,28 +5,35 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 
 import pytest
-from backend import compute_component_score, Component, Material
+from backend import (
+    compute_component_score,
+    compute_component_weight,
+    Component,
+    Material,
+)
 
 
 def test_compute_component_score_atomic():
     mat = Material(id=1, name="Steel", co2_value=2.0)
-    comp = Component(id=1, is_atomic=True, weight=3.0, material=mat)
+    comp = Component(id=1, is_atomic=True, weight=3, material=mat)
     score = compute_component_score(comp, None)
     assert score == 6.0
 
 
 def test_compute_component_score_hierarchy():
     mat = Material(id=1, name="Steel", co2_value=5.0)
-    child = Component(id=2, name="child", is_atomic=True, weight=1.0, material=mat)
+    child = Component(id=2, name="child", is_atomic=True, weight=1, material=mat)
     root = Component(
         id=3,
         name="root",
         is_atomic=False,
-        weight=2.0,
+        weight=None,
         reusable=False,
         connection_type="screwed",
     )
     root.children.append(child)
     child.parent = root
+    compute_component_weight(root)
+    assert root.weight == child.weight
     score = compute_component_score(root, None)
-    assert pytest.approx(score) == 9.5
+    assert pytest.approx(score) == 4.75


### PR DESCRIPTION
## Summary
- store component `weight` as an `INTEGER` in the DB
- update Pydantic model annotations
- compute parent component weights from children
- rely on those weights when calculating sustainability scores
- extend startup migration to ensure integer weight column
- adjust tests for integer weights and verify parent weight sums

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q httpx pytest-asyncio trio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687120587a5c8328a1a838a0c716e3f0