### PR TITLE
Introduce weight propagation and adjust compute tests

### DIFF
--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -5,7 +5,12 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
 
 import pytest
-from backend import compute_component_score, Component, Material
+from backend import (
+    compute_component_score,
+    compute_component_weight,
+    Component,
+    Material,
+)
 
 
 def test_compute_component_score_atomic():
@@ -22,11 +27,26 @@ def test_compute_component_score_hierarchy():
         id=3,
         name="root",
         is_atomic=False,
-        weight=2.0,
+        weight=None,
         reusable=False,
-        connection_type="screwed",
+        connection_strength=95,
     )
     root.children.append(child)
     child.parent = root
+    compute_component_weight(root)
+    assert root.weight == pytest.approx(child.weight)
     score = compute_component_score(root, None)
-    assert pytest.approx(score) == 9.5
+    assert pytest.approx(score) == 4.75
+
+
+def test_compute_component_weight_propagates():
+    mat = Material(id=1, name="Steel", co2_value=1.0)
+    c1 = Component(id=1, name="c1", is_atomic=True, weight=1.5, material=mat)
+    c2 = Component(id=2, name="c2", is_atomic=True, weight=2.5, material=mat)
+    parent = Component(id=3, name="p", is_atomic=False, weight=None)
+    parent.children.extend([c1, c2])
+    c1.parent = parent
+    c2.parent = parent
+
+    compute_component_weight(parent)
+    assert parent.weight == pytest.approx(c1.weight + c2.weight)


### PR DESCRIPTION
## Summary
- add `connection_strength` and weight propagation helper
- compute score using numeric connection strength
- update weight calculation on startup
- rewrite compute tests for new logic

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_b_6871205ae31083289520f64e81415a32