### PR TITLE
Rename sustainability_score field

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -145,7 +145,7 @@ class ComponentRead(ComponentBase):
 class SustainabilityBase(BaseModel):
     component_id: int
     name: str
-    sustainability_score: float
+    score: float
 
 
 class SustainabilityRead(SustainabilityBase):


### PR DESCRIPTION
## Summary
- rename `sustainability_score` to `score` in Pydantic models
- keep frontend display of the score

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_687668b3e29c83289a08f894034cd361