### PR TITLE
Add Graphviz component view

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python.
 ## Requirements
 
 - **Python 3.10+**
-- `fastapi`, `sqlalchemy`, `uvicorn`, `streamlit`, `requests`
+- `fastapi`, `sqlalchemy`, `uvicorn`, `streamlit`, `requests`, `graphviz`
 
 Install the dependencies with:
 
@@ -64,6 +64,9 @@ ways:
    export BACKEND_URL="http://localhost:8000"
    streamlit run frontend.py
    ```
+
+The components page also displays a Graphviz diagram of the component hierarchy.
+This requires the `graphviz` Python package from `requirements.txt`.
 
 ## Packaging with PyInstaller
 

--- a/frontend.py
+++ b/frontend.py
@@ -1,6 +1,7 @@
 import os
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
+from graphviz import Digraph
 import requests
 
 # Fallback-Logik für BACKEND_URL: zuerst st.secrets, dann ENV, sonst Default
@@ -62,6 +63,18 @@ def get_components():
         return r.json()
     except Exception:
         return []
+
+
+def build_graphviz_tree(items):
+    dot = Digraph()
+    for comp in items:
+        label = f"{comp['name']}\nLevel {comp.get('level', '')}"
+        dot.node(str(comp['id']), label)
+    for comp in items:
+        parent = comp.get('parent_id')
+        if parent:
+            dot.edge(str(parent), str(comp['id']))
+    return dot
 
 
 st.title("DIMOP 2.2")
@@ -301,6 +314,7 @@ elif page == "Components":
                 display_tree(node['children'], level + 1)
 
     st.header("Component hierarchy")
+    st.graphviz_chart(build_graphviz_tree(components))
     tree = build_tree(components)
     display_tree(tree)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ streamlit
 requests
 flake8
 python-multipart
+graphviz

--- a/tests/test_graphviz.py
+++ b/tests/test_graphviz.py
@@ -1,0 +1,13 @@
+import frontend
+
+
+def test_build_graphviz_tree():
+    components = [
+        {"id": 1, "name": "Root", "level": 0, "parent_id": None},
+        {"id": 2, "name": "Child", "level": 1, "parent_id": 1},
+    ]
+    dot = frontend.build_graphviz_tree(components)
+    src = dot.source
+    assert '1 [label="Root' in src
+    assert '2 [label="Child' in src
+    assert '1 -> 2' in src


### PR DESCRIPTION
## Summary
- show component tree using graphviz in the Streamlit frontend
- expose helper `build_graphviz_tree` for creating Graphviz graphs
- add graphviz to runtime dependencies
- note new graph feature and dependency in the README
- test helper with a unit test

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68766d8348ac8328af0e178e427cc821