### PR TITLE
Add CSV export/import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ Check the code style using the linter:
 ruff check .
 ```
 
+## CSV export/import
+
+Two helper endpoints make it easy to backup the database contents.
+
+- `GET /export` returns all materials and components in a single CSV file. Each
+  row includes a `model` column with either `material` or `component` and the
+  corresponding fields.
+- `POST /import` accepts an uploaded CSV (field name `file`) and recreates the
+  records in the database.
+
 ## Future authentication integration
 
 The example application intentionally omits user authentication to keep the

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -1,0 +1,86 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+import httpx
+from httpx import ASGITransport
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
+from sqlalchemy.orm import sessionmaker
+import backend
+import pytest
+
+pytest_plugins = ["tests.test_api"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_export_import_roundtrip(async_client):
+    login = await async_client.post(
+        "/token",
+        data={"username": "admin", "password": "secret"},
+    )
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = await async_client.post(
+        "/materials",
+        json={"name": "Steel"},
+        headers=headers,
+    )
+    material_id = resp.json()["id"]
+
+    await async_client.post(
+        "/components",
+        json={"name": "Root", "material_id": material_id},
+        headers=headers,
+    )
+
+    resp = await async_client.get("/export", headers=headers)
+    assert resp.status_code == 200
+    csv_data = resp.text
+
+    engine2 = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    with engine2.connect() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE materials (id INTEGER PRIMARY KEY, name VARCHAR, description VARCHAR)"
+            )
+        )
+    TestingSessionLocal = sessionmaker(
+        bind=engine2, autoflush=False, autocommit=False
+    )
+    backend.engine = engine2
+    backend.SessionLocal = TestingSessionLocal
+    backend.on_startup()
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    backend.app.dependency_overrides[backend.get_db] = override_get_db
+    transport = ASGITransport(app=backend.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+        login2 = await ac.post(
+            "/token",
+            data={"username": "admin", "password": "secret"},
+        )
+        token2 = login2.json()["access_token"]
+        headers2 = {"Authorization": f"Bearer {token2}"}
+        files = {"file": ("data.csv", csv_data, "text/csv")}
+        resp = await ac.post("/import", files=files, headers=headers2)
+        assert resp.status_code == 200
+
+        resp = await ac.get("/materials", headers=headers2)
+        assert len(resp.json()) == 1
+        resp = await ac.get("/components", headers=headers2)
+        assert len(resp.json()) == 1
+
+    backend.app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- implement CSV export and import routes in the FastAPI backend
- cover the round-trip behaviour with a new pytest test
- document the new endpoints

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687e5321d51c8328a6ca05a9f96382aa