### PR TITLE
Improve frontend error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ ways:
 The components page also displays a Graphviz diagram of the component hierarchy.
 This requires the `graphviz` Python package from `requirements.txt`.
 
+Requests for materials and components are only made once a project is
+selected. If an API call fails, the backend's error text is displayed in the
+Streamlit UI.
+
 ## Packaging with PyInstaller
 
 You can create a standalone executable of either entry point using

--- a/frontend.py
+++ b/frontend.py
@@ -24,29 +24,39 @@ AUTH_HEADERS = {}
 
 
 def get_materials():
+    project_id = st.session_state.get("project_id")
+    if not project_id:
+        return []
     try:
         r = requests.get(
             f"{BACKEND_URL}/materials",
-            params={"project_id": st.session_state.get("project_id")},
+            params={"project_id": project_id},
             headers=AUTH_HEADERS,
         )
-        r.raise_for_status()
-        return r.json()
-    except Exception:
-        return []
+        if r.ok:
+            return r.json()
+        st.error(r.text)
+    except Exception as e:
+        st.error(str(e))
+    return []
 
 
 def get_components():
+    project_id = st.session_state.get("project_id")
+    if not project_id:
+        return []
     try:
         r = requests.get(
             f"{BACKEND_URL}/components",
-            params={"project_id": st.session_state.get("project_id")},
+            params={"project_id": project_id},
             headers=AUTH_HEADERS,
         )
-        r.raise_for_status()
-        return r.json()
-    except Exception:
-        return []
+        if r.ok:
+            return r.json()
+        st.error(r.text)
+    except Exception as e:
+        st.error(str(e))
+    return []
 
 
 def get_projects():


### PR DESCRIPTION
## Summary
- in the frontend, only request materials/components when a project is selected
- show backend error text when a request fails
- document behaviour in README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880e47d6a5c8328843c6b925b710a79