### PR TITLE
Enable SQLite foreign keys

### DIFF
--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -53,7 +53,7 @@ async def test_export_import_roundtrip(async_client):
 
     engine2 = create_engine(
         "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
+        connect_args={"check_same_thread": False, "foreign_keys": 1},
         poolclass=StaticPool,
     )
     with engine2.connect() as conn:
@@ -85,6 +85,11 @@ async def test_export_import_roundtrip(async_client):
         )
         token2 = login2.json()["access_token"]
         headers2 = {"Authorization": f"Bearer {token2}"}
+        await ac.post(
+            "/projects",
+            json={"name": "Proj"},
+            headers=headers2,
+        )
         files = {"file": ("data.csv", csv_data, "text/csv")}
         resp = await ac.post("/import", files=files, headers=headers2)
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- turn on SQLite foreign key support for all new connections
- enable the pragma on startup
- verify cascading deletes in a new test
- adjust import test for foreign key constraints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880e5b57a8c83289580f2ed5c06cb32