### PR TITLE
Refactor evaluation logic and remove auth

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -116,22 +116,14 @@ async def async_client_missing_columns():
 
 @pytest.mark.anyio("asyncio")
 async def test_create_and_read_materials(async_client):
-    login = await async_client.post(
-        "/token",
-        data={"username": "admin", "password": "secret"},
-    )
-    token = login.json()["access_token"]
-    headers = {"Authorization": f"Bearer {token}"}
-
     proj_resp = await async_client.post(
-        "/projects", json={"name": "Proj"}, headers=headers
+        "/projects", json={"name": "Proj"}
     )
     project_id = proj_resp.json()["id"]
 
     resp = await async_client.post(
         "/materials",
         json={"name": "Steel", "project_id": project_id},
-        headers=headers,
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -140,7 +132,6 @@ async def test_create_and_read_materials(async_client):
     resp = await async_client.get(
         "/materials",
         params={"project_id": project_id},
-        headers=headers,
     )
     assert resp.status_code == 200
     items = resp.json()
@@ -150,22 +141,14 @@ async def test_create_and_read_materials(async_client):
 
 @pytest.mark.anyio("asyncio")
 async def test_startup_adds_component_columns(async_client_missing_columns):
-    login = await async_client_missing_columns.post(
-        "/token",
-        data={"username": "admin", "password": "secret"},
-    )
-    token = login.json()["access_token"]
-    headers = {"Authorization": f"Bearer {token}"}
-
     proj_resp = await async_client_missing_columns.post(
-        "/projects", json={"name": "Proj"}, headers=headers
+        "/projects", json={"name": "Proj"}
     )
     project_id = proj_resp.json()["id"]
 
     resp = await async_client_missing_columns.post(
         "/materials",
         json={"name": "Steel", "project_id": project_id},
-        headers=headers,
     )
     material_id = resp.json()["id"]
 
@@ -176,7 +159,6 @@ async def test_startup_adds_component_columns(async_client_missing_columns):
             "material_id": material_id,
             "project_id": project_id,
         },
-        headers=headers,
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -195,31 +177,21 @@ async def test_startup_adds_component_columns(async_client_missing_columns):
 
 @pytest.mark.anyio("asyncio")
 async def test_duplicate_material_name_returns_400(async_client_full_schema):
-    login = await async_client_full_schema.post(
-        "/token",
-        data={"username": "admin", "password": "secret"},
-    )
-    token = login.json()["access_token"]
-    headers = {"Authorization": f"Bearer {token}"}
-
     proj_resp = await async_client_full_schema.post(
         "/projects",
         json={"name": "Proj"},
-        headers=headers,
     )
     project_id = proj_resp.json()["id"]
 
     first = await async_client_full_schema.post(
         "/materials",
         json={"name": "Steel", "project_id": project_id},
-        headers=headers,
     )
     assert first.status_code == 200
 
     second = await async_client_full_schema.post(
         "/materials",
         json={"name": "Steel", "project_id": project_id},
-        headers=headers,
     )
     assert second.status_code == 400
     assert second.json()["detail"] == "Material name already exists"
@@ -227,31 +199,21 @@ async def test_duplicate_material_name_returns_400(async_client_full_schema):
 
 @pytest.mark.anyio("asyncio")
 async def test_delete_material_cascades_components(async_client_full_schema):
-    login = await async_client_full_schema.post(
-        "/token",
-        data={"username": "admin", "password": "secret"},
-    )
-    token = login.json()["access_token"]
-    headers = {"Authorization": f"Bearer {token}"}
-
     proj_resp = await async_client_full_schema.post(
         "/projects",
         json={"name": "Proj"},
-        headers=headers,
     )
     project_id = proj_resp.json()["id"]
 
     mat_resp = await async_client_full_schema.post(
         "/materials",
         json={"name": "Steel", "project_id": project_id},
-        headers=headers,
     )
     material_id = mat_resp.json()["id"]
 
     await async_client_full_schema.post(
         "/components",
         json={"name": "Comp", "material_id": material_id, "project_id": project_id},
-        headers=headers,
     )
 
     # Delete using raw SQL to ensure DB-level cascading
@@ -261,7 +223,6 @@ async def test_delete_material_cascades_components(async_client_full_schema):
     resp = await async_client_full_schema.get(
         "/components",
         params={"project_id": project_id},
-        headers=headers,
     )
     assert resp.status_code == 200
     assert resp.json() == []

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -9,14 +9,30 @@ from backend import compute_component_score, Component, Material
 
 
 def test_compute_component_score_atomic():
-    mat = Material(id=1, name="Steel", total_gwp=2.0)
+    mat = Material(
+        id=1,
+        name="Steel",
+        total_gwp=2.0,
+        is_dangerous=False,
+        plast_fam="A",
+        system_ability=2,
+        sortability=1,
+    )
     comp = Component(id=1, is_atomic=True, weight=3.0, material=mat)
     score = compute_component_score(comp)
-    assert score == 6.0
+    assert score == 1.0
 
 
 def test_compute_component_score_hierarchy():
-    mat = Material(id=1, name="Steel", total_gwp=5.0)
+    mat = Material(
+        id=1,
+        name="Steel",
+        total_gwp=5.0,
+        is_dangerous=False,
+        plast_fam="A",
+        system_ability=2,
+        sortability=1,
+    )
     child = Component(id=2, name="child", is_atomic=True, weight=1.0, material=mat)
     root = Component(
         id=3,
@@ -29,4 +45,4 @@ def test_compute_component_score_hierarchy():
     root.children.append(child)
     child.parent = root
     score = compute_component_score(root)
-    assert pytest.approx(score) == 9.5
+    assert score == 1.0


### PR DESCRIPTION
## Summary
- add plastic and hazard fields to materials and extend CSV import/export
- drop authentication from backend and frontend
- implement new sustainability evaluation algorithm
- update tests accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: no module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_b_6889df87785083289eecfebfa882ed29