### PR TITLE
Add sustainability extensions

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -191,6 +191,15 @@ async def test_startup_adds_component_columns(async_client_missing_columns):
     assert "fossil_gwp" in mat_cols
     assert "biogenic_gwp" in mat_cols
     assert "adpf" in mat_cols
+    assert "is_dangerous" in mat_cols
+    assert "plast_fam" in mat_cols
+    assert "mara_plast_id" in mat_cols
+
+    tables = inspector.get_table_names()
+    assert "sys_sort" in tables
+    assert "plast" in tables
+    assert "rel" in tables
+    assert "compability" in tables
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
## Summary
- extend material columns with dangerous indicator and plastics info
- introduce SysSort, Plast, Rel and Compability lookup tables
- rewrite component score to calculate f1–f4 factors
- run migrations on startup for new columns and tables
- test creation of new DB schema pieces

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889e696b98c8332a05162f2193e0b61