### PR TITLE
Implement component evaluation endpoint

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -454,6 +454,30 @@ elif page == "Components":
         for entry in st.session_state.sustainability:
             st.write(f"{entry['name']}: {entry['score']:.2f}")
 
+    st.header("Evaluate component")
+    if components:
+        eval_map = {f"{c['name']} (id:{c['id']})": c['id'] for c in components}
+        sel_eval = st.selectbox("Component to evaluate", list(eval_map.keys()))
+        if st.button("Run evaluation"):
+            try:
+                res = requests.post(
+                    f"{BACKEND_URL}/evaluation/{eval_map[sel_eval]}",
+                    params={"project_id": st.session_state.get("project_id")},
+                    headers=AUTH_HEADERS,
+                )
+                res.raise_for_status()
+                st.session_state.evaluation = res.json()
+            except Exception as e:
+                st.error(str(e))
+        if st.session_state.get("evaluation"):
+            ev = st.session_state.evaluation
+            st.write(f"RV: {ev['rv']:.2f}")
+            st.write(f"Grade: {ev['grade']}")
+            st.write(
+                f"Total GWP: {ev['total_gwp']:.2f}, Fossil: {ev['fossil_gwp']:.2f}, "
+                f"Biogenic: {ev['biogenic_gwp']:.2f}, ADPf: {ev['adpf']:.2f}"
+            )
+    
 elif page == "Export/Import":
     st.header("Export database")
     if st.button("Download CSV"):

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,81 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+
+from tests.test_api import async_client_full_schema
+
+
+@pytest.mark.anyio("asyncio")
+async def test_evaluation_endpoint(async_client_full_schema):
+    client = async_client_full_schema
+    login = await client.post("/token", data={"username": "admin", "password": "secret"})
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    proj = await client.post("/projects", json={"name": "Proj"}, headers=headers)
+    project_id = proj.json()["id"]
+
+    mat1 = await client.post(
+        "/materials",
+        json={
+            "name": "Steel",
+            "project_id": project_id,
+            "total_gwp": 10.0,
+            "fossil_gwp": 6.0,
+            "biogenic_gwp": 4.0,
+            "adpf": 2.0,
+        },
+        headers=headers,
+    )
+    mat1_id = mat1.json()["id"]
+
+    mat2 = await client.post(
+        "/materials",
+        json={
+            "name": "Wood",
+            "project_id": project_id,
+            "total_gwp": 5.0,
+            "fossil_gwp": 2.0,
+            "biogenic_gwp": 1.0,
+            "adpf": 1.0,
+        },
+        headers=headers,
+    )
+    mat2_id = mat2.json()["id"]
+
+    root = await client.post(
+        "/components",
+        json={"name": "Root", "material_id": mat1_id, "weight": 2.0, "project_id": project_id},
+        headers=headers,
+    )
+    root_id = root.json()["id"]
+
+    child = await client.post(
+        "/components",
+        json={
+            "name": "Child",
+            "material_id": mat2_id,
+            "parent_id": root_id,
+            "weight": 1.0,
+            "project_id": project_id,
+        },
+        headers=headers,
+    )
+    assert child.status_code == 200
+
+    resp = await client.post(
+        f"/evaluation/{root_id}",
+        params={"project_id": project_id},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["rv"] == pytest.approx(25.0)
+    assert data["grade"] == "B"
+    assert data["total_gwp"] == pytest.approx(25.0)
+    assert data["fossil_gwp"] == pytest.approx(14.0)
+    assert data["biogenic_gwp"] == pytest.approx(9.0)
+    assert data["adpf"] == pytest.approx(5.0)


### PR DESCRIPTION
## Summary
- implement recursive metric aggregation and `/evaluation/{component_id}` in FastAPI backend
- integrate component evaluation into Streamlit frontend
- add tests covering the new endpoint

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889e86268e88332bba88f7b6817b526