### PR TITLE
Add volume and density fields to components

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python -m uvicorn backend:app --reload
 ### Upgrade from previous versions
 
 Version 2.2 introduces several global warming potential columns on the `materials` table: `total_gwp`, `fossil_gwp`, `biogenic_gwp`, and `adpf`.
-Newer versions may also require additional columns on the `components` table, such as `connection_type` and `weight`.
+Newer versions may also require additional columns on the `components` table, such as `connection_type`, `volume`, and `density`.
 Because the example doesn't use a migration tool, you have two options when upgrading: delete the existing `app.db` file and let FastAPI recreate it on the next startup, or manually add the missing columns using `ALTER TABLE` statements. Without this step the API will fail to start with errors such as `no such column: materials.total_gwp`.
 
 ```sql
@@ -35,7 +35,8 @@ ALTER TABLE materials ADD COLUMN fossil_gwp FLOAT;
 ALTER TABLE materials ADD COLUMN biogenic_gwp FLOAT;
 ALTER TABLE materials ADD COLUMN adpf FLOAT;
 ALTER TABLE components ADD COLUMN connection_type INTEGER;
-ALTER TABLE components ADD COLUMN weight INTEGER;
+ALTER TABLE components ADD COLUMN volume FLOAT;
+ALTER TABLE components ADD COLUMN density FLOAT;
 ```
 
 ## Starting the Streamlit frontend

--- a/frontend.py
+++ b/frontend.py
@@ -296,7 +296,8 @@ elif page == "Components":
         }
         parent_sel = st.selectbox("Parent component", list(parent_map.keys()))
         is_atomic = st.checkbox("Atomic")
-        weight = st.number_input("Weight", value=0.0)
+        volume = st.number_input("Volume", value=0.0)
+        density = st.number_input("Density", value=0.0)
         reusable = st.checkbox("Reusable")
         connection_type = st.number_input("Connection type", value=0, step=1)
         submitted = st.form_submit_button("Create")
@@ -310,7 +311,8 @@ elif page == "Components":
                     "level": level,
                     "parent_id": parent_map[parent_sel],
                     "is_atomic": is_atomic,
-                    "weight": weight,
+                    "volume": volume,
+                    "density": density,
                     "reusable": reusable,
                     "connection_type": connection_type,
                 },
@@ -374,9 +376,13 @@ elif page == "Components":
                 "Atomic",
                 value=comp.get("is_atomic", False),
             )
-            up_weight = st.number_input(
-                "Weight",
-                value=comp.get("weight", 0.0) or 0.0,
+            up_volume = st.number_input(
+                "Volume",
+                value=comp.get("volume", 0.0) or 0.0,
+            )
+            up_density = st.number_input(
+                "Density",
+                value=comp.get("density", 0.0) or 0.0,
             )
             up_reusable = st.checkbox(
                 "Reusable",
@@ -398,7 +404,8 @@ elif page == "Components":
                         "level": up_level,
                         "parent_id": parent_map[up_parent],
                         "is_atomic": up_atomic,
-                        "weight": up_weight,
+                        "volume": up_volume,
+                        "density": up_density,
                         "reusable": up_reusable,
                         "connection_type": up_conn,
                     },

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -10,19 +10,20 @@ from backend import compute_component_score, Component, Material
 
 def test_compute_component_score_atomic():
     mat = Material(id=1, name="Steel", total_gwp=2.0)
-    comp = Component(id=1, is_atomic=True, weight=3.0, material=mat)
+    comp = Component(id=1, is_atomic=True, volume=3.0, density=1.0, material=mat)
     score = compute_component_score(comp)
     assert score == 6.0
 
 
 def test_compute_component_score_hierarchy():
     mat = Material(id=1, name="Steel", total_gwp=5.0)
-    child = Component(id=2, name="child", is_atomic=True, weight=1.0, material=mat)
+    child = Component(id=2, name="child", is_atomic=True, volume=1.0, density=1.0, material=mat)
     root = Component(
         id=3,
         name="root",
         is_atomic=False,
-        weight=2.0,
+        volume=2.0,
+        density=1.0,
         reusable=False,
         connection_type=1,
     )

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -46,7 +46,13 @@ async def test_evaluation_endpoint(async_client_full_schema):
 
     root = await client.post(
         "/components",
-        json={"name": "Root", "material_id": mat1_id, "weight": 2.0, "project_id": project_id},
+        json={
+            "name": "Root",
+            "material_id": mat1_id,
+            "volume": 2.0,
+            "density": 1.0,
+            "project_id": project_id,
+        },
         headers=headers,
     )
     root_id = root.json()["id"]
@@ -57,7 +63,8 @@ async def test_evaluation_endpoint(async_client_full_schema):
             "name": "Child",
             "material_id": mat2_id,
             "parent_id": root_id,
-            "weight": 1.0,
+            "volume": 1.0,
+            "density": 1.0,
             "project_id": project_id,
         },
         headers=headers,

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -79,6 +79,8 @@ async def test_export_import_roundtrip(async_client):
     assert "is_dangerous" in reader.fieldnames
     assert "plast_fam" in reader.fieldnames
     assert "mara_plast_id" in reader.fieldnames
+    assert "volume" in reader.fieldnames
+    assert "density" in reader.fieldnames
     assert "component_id" in reader.fieldnames
     assert "score" in reader.fieldnames
     assert rows[0]["total_gwp"] == "10.0"


### PR DESCRIPTION
## Summary
- replace `weight` field with `volume` and `density` on Component model and schemas
- compute weight dynamically and migrate existing databases
- adjust import/export, frontend, and tests for new fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c59491c0c83289cfa49056066b075