### PR TITLE
Derive component weights from volume and density

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -95,6 +95,8 @@ class Component(Base):
     )
     is_atomic = Column(Boolean, default=False)
     weight = Column(Float, nullable=True)
+    volume = Column(Float, nullable=True)
+    density = Column(Float, nullable=True)
     reusable = Column(Boolean, default=False)
     connection_type = Column(Integer, nullable=True)
     project_id = Column(Integer, ForeignKey("projects.id"))
@@ -115,6 +117,21 @@ class Component(Base):
         back_populates="parent",
         cascade="all, delete-orphan",
     )
+
+    def get_weight(self) -> float:
+        """Return the effective weight of the component.
+
+        Priority of weight sources:
+        1. Explicit `weight` attribute if provided.
+        2. Derived from `volume` and `density`.
+        3. Default of 0 for atomic components and 1 for others.
+        """
+
+        if self.weight is not None:
+            return self.weight
+        if self.volume is not None and self.density is not None:
+            return self.volume * self.density
+        return 0.0 if self.is_atomic else 1.0
 
 
 class Sustainability(Base):
@@ -210,6 +227,8 @@ class ComponentBase(BaseModel):
     parent_id: Optional[int] = None
     is_atomic: Optional[bool] = None
     weight: Optional[float] = None
+    volume: Optional[float] = None
+    density: Optional[float] = None
     reusable: Optional[bool] = None
     connection_type: Optional[int] = None
     project_id: int
@@ -261,7 +280,7 @@ def compute_component_score(
         return cache[component.id]
 
     if component.is_atomic:
-        f1 = component.weight or 0
+        f1 = component.get_weight()
         f2 = component.material.total_gwp or 0
         f3 = 1.0
         f4 = 1.0
@@ -270,7 +289,7 @@ def compute_component_score(
             compute_component_score(child, cache)
             for child in component.children
         ]
-        f1 = component.weight or 1
+        f1 = component.get_weight()
         f2 = sum(child_scores)
         f3 = 0.9 if component.reusable else 1.0
         level = component.connection_type or 0
@@ -352,6 +371,8 @@ def on_startup():
             ("parent_id", "INTEGER"),
             ("is_atomic", "BOOLEAN"),
             ("weight", "FLOAT"),
+            ("volume", "FLOAT"),
+            ("density", "FLOAT"),
             ("reusable", "BOOLEAN"),
             ("connection_type", "INTEGER"),
             ("project_id", "INTEGER"),
@@ -808,7 +829,7 @@ async def import_csv(
 
 def _aggregate_metrics(component: Component) -> Dict[str, float]:
     """Recursively sum GWP and ADPf for component tree."""
-    weight = component.weight or 1.0
+    weight = component.get_weight()
     mat = component.material
     total = (mat.total_gwp or 0.0) * weight
     fossil = (mat.fossil_gwp or 0.0) * weight

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -30,3 +30,27 @@ def test_compute_component_score_hierarchy():
     child.parent = root
     score = compute_component_score(root)
     assert pytest.approx(score) == 9.5
+
+
+def test_compute_component_score_volume_density():
+    mat = Material(id=1, name="Steel", total_gwp=2.0)
+    comp = Component(id=1, is_atomic=True, volume=3.0, density=2.0, material=mat)
+    score = compute_component_score(comp)
+    assert score == 12.0
+
+
+def test_compute_component_score_default_weight_non_atomic():
+    mat = Material(id=1, name="Steel", total_gwp=5.0)
+    child = Component(id=2, is_atomic=True, weight=1.0, material=mat)
+    root = Component(
+        id=3,
+        name="root",
+        is_atomic=False,
+        reusable=False,
+        connection_type=1,
+        material=mat,
+    )
+    root.children.append(child)
+    child.parent = root
+    score = compute_component_score(root)
+    assert pytest.approx(score) == 4.75


### PR DESCRIPTION
## Summary
- Add `volume` and `density` fields for components and a `get_weight` helper that falls back to 1.0 for non-atomic components lacking weight data
- Use `get_weight` in `compute_component_score` and `_aggregate_metrics` to consistently rely on derived weights
- Extend component schemas and migrations for the new fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c6a5a5c7c8328aff45aed69dc4e0a