### PR TITLE
Replace weight uses in tests with volume/density

### DIFF
--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -10,20 +10,20 @@ from backend import compute_component_score, Component, Material
 
 def test_compute_component_score_atomic():
     mat = Material(id=1, name="Steel", total_gwp=2.0)
-    comp = Component(id=1, is_atomic=True, volume=3.0, density=1.0, material=mat)
+    comp = Component(id=1, is_atomic=True, volume=1.5, density=2.0, material=mat)
     score = compute_component_score(comp)
     assert score == 6.0
 
 
 def test_compute_component_score_hierarchy():
     mat = Material(id=1, name="Steel", total_gwp=5.0)
-    child = Component(id=2, name="child", is_atomic=True, volume=1.0, density=1.0, material=mat)
+    child = Component(id=2, name="child", is_atomic=True, volume=0.5, density=2.0, material=mat)
     root = Component(
         id=3,
         name="root",
         is_atomic=False,
-        volume=2.0,
-        density=1.0,
+        volume=1.0,
+        density=2.0,
         reusable=False,
         connection_type=1,
     )
@@ -35,14 +35,14 @@ def test_compute_component_score_hierarchy():
 
 def test_compute_component_score_volume_density():
     mat = Material(id=1, name="Steel", total_gwp=2.0)
-    comp = Component(id=1, is_atomic=True, volume=3.0, density=2.0, material=mat)
+    comp = Component(id=1, is_atomic=True, volume=1.5, density=4.0, material=mat)
     score = compute_component_score(comp)
     assert score == 12.0
 
 
 def test_compute_component_score_default_weight_non_atomic():
     mat = Material(id=1, name="Steel", total_gwp=5.0)
-    child = Component(id=2, is_atomic=True, volume=1.0, density=1.0, material=mat)
+    child = Component(id=2, is_atomic=True, volume=0.5, density=2.0, material=mat)
     root = Component(
         id=3,
         name="root",

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -6,6 +6,9 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import pytest
 
 
+pytest_plugins = ["tests.test_api"]
+
+
 @pytest.mark.anyio("asyncio")
 async def test_evaluation_endpoint(async_client_full_schema):
     client = async_client_full_schema
@@ -49,8 +52,8 @@ async def test_evaluation_endpoint(async_client_full_schema):
         json={
             "name": "Root",
             "material_id": mat1_id,
-            "volume": 2.0,
-            "density": 1.0,
+            "volume": 0.5,
+            "density": 4.0,
             "project_id": project_id,
         },
         headers=headers,
@@ -63,8 +66,8 @@ async def test_evaluation_endpoint(async_client_full_schema):
             "name": "Child",
             "material_id": mat2_id,
             "parent_id": root_id,
-            "volume": 1.0,
-            "density": 1.0,
+            "volume": 0.25,
+            "density": 4.0,
             "project_id": project_id,
         },
         headers=headers,


### PR DESCRIPTION
## Summary
- refactor compute score tests to supply volume and density instead of weight
- update evaluation test to post components using volume and density and import shared fixtures

## Testing
- `pytest tests/test_compute.py tests/test_evaluation.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689c73226fdc8328a0d90e2f899e12b2