### PR TITLE
Store material density and compute component weight

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -161,6 +161,7 @@ if page == "Materials":
         fossil_gwp = st.number_input("Fossil - GWP", value=0.0)
         biogenic_gwp = st.number_input("Biogenic - GWP", value=0.0)
         adpf = st.number_input("ADPF", value=0.0)
+        density = st.number_input("Density", value=0.0)
         is_dangerous = st.checkbox("Dangerous")
         plast_fam = st.text_input("Plastic family")
         mara_plast_id = st.number_input("mara_plast_id", value=0, step=1)
@@ -175,6 +176,7 @@ if page == "Materials":
                     "fossil_gwp": fossil_gwp,
                     "biogenic_gwp": biogenic_gwp,
                     "adpf": adpf,
+                    "density": density,
                     "is_dangerous": is_dangerous,
                     "plast_fam": plast_fam,
                     "mara_plast_id": mara_plast_id,
@@ -212,6 +214,10 @@ if page == "Materials":
                 "ADPF",
                 value=mat.get("adpf", 0.0) or 0.0,
             )
+            up_density = st.number_input(
+                "Density",
+                value=mat.get("density", 0.0) or 0.0,
+            )
             up_danger = st.checkbox(
                 "Dangerous",
                 value=mat.get("is_dangerous", False),
@@ -236,6 +242,7 @@ if page == "Materials":
                         "fossil_gwp": up_fossil,
                         "biogenic_gwp": up_bio,
                         "adpf": up_adpf,
+                        "density": up_density,
                         "is_dangerous": up_danger,
                         "plast_fam": up_plast,
                         "mara_plast_id": up_mara,
@@ -297,7 +304,6 @@ elif page == "Components":
         parent_sel = st.selectbox("Parent component", list(parent_map.keys()))
         is_atomic = st.checkbox("Atomic")
         volume = st.number_input("Volume", value=0.0)
-        density = st.number_input("Density", value=0.0)
         reusable = st.checkbox("Reusable")
         connection_type = st.number_input("Connection type", value=0, step=1)
         submitted = st.form_submit_button("Create")
@@ -312,7 +318,6 @@ elif page == "Components":
                     "parent_id": parent_map[parent_sel],
                     "is_atomic": is_atomic,
                     "volume": volume,
-                    "density": density,
                     "reusable": reusable,
                     "connection_type": connection_type,
                 },
@@ -380,10 +385,6 @@ elif page == "Components":
                 "Volume",
                 value=comp.get("volume", 0.0) or 0.0,
             )
-            up_density = st.number_input(
-                "Density",
-                value=comp.get("density", 0.0) or 0.0,
-            )
             up_reusable = st.checkbox(
                 "Reusable",
                 value=comp.get("reusable", False),
@@ -405,7 +406,6 @@ elif page == "Components":
                         "parent_id": parent_map[up_parent],
                         "is_atomic": up_atomic,
                         "volume": up_volume,
-                        "density": up_density,
                         "reusable": up_reusable,
                         "connection_type": up_conn,
                     },
@@ -420,17 +420,15 @@ elif page == "Components":
 
     st.header("Existing components")
     for c in components:
-        mat_name = next(
-            (m['name'] for m in materials if m['id'] == c['material_id']),
-            'N/A',
-        )
+        mat = next((m for m in materials if m['id'] == c['material_id']), None)
+        mat_name = mat['name'] if mat else 'N/A'
+        mat_density = mat.get('density') if mat else None
         vol = c.get('volume')
-        dens = c.get('density')
-        weight = vol * dens if vol is not None and dens is not None else None
+        weight = c.get('weight')
         info = (
             f"Material: {mat_name}, "
             f"Volume: {vol if vol is not None else 'N/A'}, "
-            f"Density: {dens if dens is not None else 'N/A'}"
+            f"Density: {mat_density if mat_density is not None else 'N/A'}"
         )
         if weight is not None:
             info += f", Weight: {weight}"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -191,6 +191,7 @@ async def test_startup_adds_component_columns(async_client_missing_columns):
     assert "fossil_gwp" in mat_cols
     assert "biogenic_gwp" in mat_cols
     assert "adpf" in mat_cols
+    assert "density" in mat_cols
     assert "is_dangerous" in mat_cols
     assert "plast_fam" in mat_cols
     assert "mara_plast_id" in mat_cols

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -9,23 +9,24 @@ from backend import compute_component_score, Component, Material
 
 
 def test_compute_component_score_atomic():
-    mat = Material(id=1, name="Steel", total_gwp=2.0)
-    comp = Component(id=1, is_atomic=True, volume=1.5, density=2.0, material=mat)
+    mat = Material(id=1, name="Steel", total_gwp=2.0, density=2.0)
+    comp = Component(id=1, is_atomic=True, volume=1.5, weight=3.0, material=mat)
     score = compute_component_score(comp)
     assert score == 6.0
 
 
 def test_compute_component_score_hierarchy():
-    mat = Material(id=1, name="Steel", total_gwp=5.0)
-    child = Component(id=2, name="child", is_atomic=True, volume=0.5, density=2.0, material=mat)
+    mat = Material(id=1, name="Steel", total_gwp=5.0, density=2.0)
+    child = Component(id=2, name="child", is_atomic=True, volume=0.5, weight=1.0, material=mat)
     root = Component(
         id=3,
         name="root",
         is_atomic=False,
         volume=1.0,
-        density=2.0,
+        weight=2.0,
         reusable=False,
         connection_type=1,
+        material=mat,
     )
     root.children.append(child)
     child.parent = root
@@ -34,15 +35,15 @@ def test_compute_component_score_hierarchy():
 
 
 def test_compute_component_score_volume_density():
-    mat = Material(id=1, name="Steel", total_gwp=2.0)
-    comp = Component(id=1, is_atomic=True, volume=1.5, density=4.0, material=mat)
+    mat = Material(id=1, name="Steel", total_gwp=2.0, density=4.0)
+    comp = Component(id=1, is_atomic=True, volume=1.5, weight=6.0, material=mat)
     score = compute_component_score(comp)
     assert score == 12.0
 
 
 def test_compute_component_score_default_weight_non_atomic():
-    mat = Material(id=1, name="Steel", total_gwp=5.0)
-    child = Component(id=2, is_atomic=True, volume=0.5, density=2.0, material=mat)
+    mat = Material(id=1, name="Steel", total_gwp=5.0, density=2.0)
+    child = Component(id=2, is_atomic=True, volume=0.5, weight=1.0, material=mat)
     root = Component(
         id=3,
         name="root",

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -28,6 +28,7 @@ async def test_evaluation_endpoint(async_client_full_schema):
             "fossil_gwp": 6.0,
             "biogenic_gwp": 4.0,
             "adpf": 2.0,
+            "density": 4.0,
         },
         headers=headers,
     )
@@ -42,6 +43,7 @@ async def test_evaluation_endpoint(async_client_full_schema):
             "fossil_gwp": 2.0,
             "biogenic_gwp": 1.0,
             "adpf": 1.0,
+            "density": 4.0,
         },
         headers=headers,
     )
@@ -53,7 +55,6 @@ async def test_evaluation_endpoint(async_client_full_schema):
             "name": "Root",
             "material_id": mat1_id,
             "volume": 0.5,
-            "density": 4.0,
             "project_id": project_id,
         },
         headers=headers,
@@ -67,12 +68,23 @@ async def test_evaluation_endpoint(async_client_full_schema):
             "material_id": mat2_id,
             "parent_id": root_id,
             "volume": 0.25,
-            "density": 4.0,
             "project_id": project_id,
         },
         headers=headers,
     )
     assert child.status_code == 200
+    root_read = await client.get(
+        f"/components/{root_id}",
+        params={"project_id": project_id},
+        headers=headers,
+    )
+    assert root_read.json()["weight"] == pytest.approx(2.0)
+    child_read = await client.get(
+        f"/components/{child.json()['id']}",
+        params={"project_id": project_id},
+        headers=headers,
+    )
+    assert child_read.json()["weight"] == pytest.approx(1.0)
 
     resp = await client.post(
         f"/evaluation/{root_id}",

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -41,6 +41,7 @@ async def test_export_import_roundtrip(async_client):
             "fossil_gwp": 5.5,
             "biogenic_gwp": 3.3,
             "adpf": 8.0,
+            "density": 7.0,
             "is_dangerous": True,
             "plast_fam": "PET",
             "mara_plast_id": 42,
@@ -81,12 +82,14 @@ async def test_export_import_roundtrip(async_client):
     assert "mara_plast_id" in reader.fieldnames
     assert "volume" in reader.fieldnames
     assert "density" in reader.fieldnames
+    assert "weight" in reader.fieldnames
     assert "component_id" in reader.fieldnames
     assert "score" in reader.fieldnames
     assert rows[0]["total_gwp"] == "10.0"
     assert rows[0]["fossil_gwp"] == "5.5"
     assert rows[0]["biogenic_gwp"] == "3.3"
     assert rows[0]["adpf"] == "8.0"
+    assert rows[0]["density"] == "7.0"
     assert rows[0]["is_dangerous"] == "True"
     assert rows[0]["plast_fam"] == "PET"
     assert rows[0]["mara_plast_id"] == "42"
@@ -148,6 +151,7 @@ async def test_export_import_roundtrip(async_client):
         assert mat["fossil_gwp"] == 5.5
         assert mat["biogenic_gwp"] == 3.3
         assert mat["adpf"] == 8.0
+        assert mat["density"] == 7.0
         assert mat["is_dangerous"] is True
         assert mat["plast_fam"] == "PET"
         assert mat["mara_plast_id"] == 42


### PR DESCRIPTION
## Summary
- Add `density` to materials and persist component `weight`
- Derive and store component weight when linking materials or updating volume/density
- Include new fields in CSV export/import and adjust frontend and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c7a220c788328b068cf39c23ce902