### PR TITLE
Allow updating material without project_id

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -210,7 +210,17 @@ class MaterialCreate(MaterialBase):
     project_id: int
 
 
-class MaterialUpdate(MaterialBase):
+class MaterialUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    total_gwp: Optional[float] = None
+    fossil_gwp: Optional[float] = None
+    biogenic_gwp: Optional[float] = None
+    adpf: Optional[float] = None
+    density: Optional[float] = None
+    is_dangerous: Optional[bool] = None
+    plast_fam: Optional[str] = None
+    mara_plast_id: Optional[int] = None
     project_id: Optional[int] = None
 
 
@@ -469,13 +479,13 @@ def read_material(
 
 @app.put("/materials/{material_id}", response_model=MaterialRead)
 def update_material(
-    material_id: int, material_update: MaterialUpdate,
-    project_id: int,
+    material_id: int,
+    material_update: MaterialUpdate,
     db: Session = Depends(get_db),
     current_user: dict = Depends(get_current_user),
 ):
     material = db.get(Material, material_id)
-    if not material or material.project_id != project_id:
+    if not material:
         raise HTTPException(status_code=404, detail="Material not found")
     updates = material_update.dict(exclude_unset=True)
     for key, value in updates.items():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -149,6 +149,37 @@ async def test_create_and_read_materials(async_client):
 
 
 @pytest.mark.anyio("asyncio")
+async def test_update_material_density_no_project_id(async_client):
+    login = await async_client.post(
+        "/token",
+        data={"username": "admin", "password": "secret"},
+    )
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    proj_resp = await async_client.post(
+        "/projects", json={"name": "Proj"}, headers=headers
+    )
+    project_id = proj_resp.json()["id"]
+
+    resp = await async_client.post(
+        "/materials",
+        json={"name": "Holz", "project_id": project_id, "density": 1.0},
+        headers=headers,
+    )
+    material_id = resp.json()["id"]
+
+    resp = await async_client.put(
+        f"/materials/{material_id}",
+        json={"density": 0.8},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["density"] == 0.8
+
+
+@pytest.mark.anyio("asyncio")
 async def test_startup_adds_component_columns(async_client_missing_columns):
     login = await async_client_missing_columns.post(
         "/token",


### PR DESCRIPTION
## Summary
- Allow partial material updates without requiring `project_id`
- Permit material updates with only the fields to change
- Cover material update without project_id in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c841a0c788328886d4e98599d2976