### PR TITLE
Remove component density column in favour of material density

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ python -m uvicorn backend:app --reload
 ### Upgrade from previous versions
 
 Version 2.2 introduces several global warming potential columns on the `materials` table: `total_gwp`, `fossil_gwp`, `biogenic_gwp`, and `adpf`.
-Newer versions may also require additional columns on the `components` table, such as `connection_type`, `volume`, and `density`.
+Newer versions may also require additional columns on the `components` table, such as `connection_type`, `volume`, and `weight`.
+If a legacy `density` column exists on `components`, it should be removed because component density is derived from the linked material.
 Because the example doesn't use a migration tool, you have two options when upgrading: delete the existing `app.db` file and let FastAPI recreate it on the next startup, or manually add the missing columns using `ALTER TABLE` statements. Without this step the API will fail to start with errors such as `no such column: materials.total_gwp`.
 
 ```sql
@@ -36,7 +37,8 @@ ALTER TABLE materials ADD COLUMN biogenic_gwp FLOAT;
 ALTER TABLE materials ADD COLUMN adpf FLOAT;
 ALTER TABLE components ADD COLUMN connection_type INTEGER;
 ALTER TABLE components ADD COLUMN volume FLOAT;
-ALTER TABLE components ADD COLUMN density FLOAT;
+ALTER TABLE components ADD COLUMN weight FLOAT;
+ALTER TABLE components DROP COLUMN density;
 ```
 
 ## Starting the Streamlit frontend
@@ -116,8 +118,8 @@ Two helper endpoints make it easy to backup the database contents.
 
 - `GET /export` returns all materials and components in a single CSV file. Each
   row includes a `model` column with either `material` or `component` and the
-  corresponding fields. Component entries contain `volume` and `density`
-  columns; the legacy `weight` field is no longer used.
+  corresponding fields. Component entries contain `volume` and `weight`
+  columns; density is stored with the referenced material.
 - `POST /import` accepts an uploaded CSV (field name `file`) and recreates the
   records in the database.
 

--- a/backend.py
+++ b/backend.py
@@ -388,6 +388,12 @@ def on_startup():
                 )
     if "components" in inspector.get_table_names():
         cols = [c["name"] for c in inspector.get_columns("components")]
+        # Remove deprecated density column if it exists; component density should
+        # always come from the linked material.
+        if "density" in cols:
+            with engine.connect() as conn:
+                conn.execute(text("ALTER TABLE components DROP COLUMN density"))
+            cols.remove("density")
         new_columns = [
             ("level", "INTEGER"),
             ("parent_id", "INTEGER"),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,7 +90,7 @@ async def async_client_missing_columns():
         )
         conn.execute(
             text(
-                "CREATE TABLE components (id INTEGER PRIMARY KEY, name VARCHAR, material_id INTEGER)"
+                "CREATE TABLE components (id INTEGER PRIMARY KEY, name VARCHAR, material_id INTEGER, density FLOAT)"
             )
         )
     TestingSessionLocal = sessionmaker(
@@ -266,6 +266,8 @@ async def test_startup_adds_component_columns(async_client_missing_columns):
     inspector = backend.inspect(backend.engine)
     cols = [c["name"] for c in inspector.get_columns("components")]
     assert "level" in cols
+    assert "weight" in cols
+    assert "density" not in cols
 
     mat_cols = [c["name"] for c in inspector.get_columns("materials")]
     assert "total_gwp" in mat_cols


### PR DESCRIPTION
## Summary
- Drop legacy `density` column from `components` table and rely on linked material's density
- Update docs to describe weight-based component schema and how to drop old `density` column
- Test migration logic to ensure component `density` column is removed

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c8d5fe6988328a7230ff5987ae49b