### PR TITLE
Implement project R-strategy selection and recycle evaluation

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -276,9 +276,7 @@ async def test_startup_adds_component_columns(async_client_missing_columns):
     assert "adpf" in mat_cols
     assert "density" in mat_cols
     assert "is_dangerous" in mat_cols
-    assert "plast_fam" in mat_cols
-    assert "mara_plast_id" in mat_cols
-
+    
     tables = inspector.get_table_names()
     assert "sys_sort" in tables
     assert "plast" in tables

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,9 +1,9 @@
 import os
 import sys
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
 import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 
 pytest_plugins = ["tests.test_api"]
@@ -12,7 +12,9 @@ pytest_plugins = ["tests.test_api"]
 @pytest.mark.anyio("asyncio")
 async def test_evaluation_endpoint(async_client_full_schema):
     client = async_client_full_schema
-    login = await client.post("/token", data={"username": "admin", "password": "secret"})
+    login = await client.post(
+        "/token", data={"username": "admin", "password": "secret"}
+    )
     token = login.json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
 

--- a/tests/test_export_import.py
+++ b/tests/test_export_import.py
@@ -1,17 +1,17 @@
+import csv
+import io
 import os
 import sys
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
-
 import httpx
 from httpx import ASGITransport
-import csv
-import io
 from sqlalchemy import create_engine, text
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import sessionmaker
-import backend
 import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import backend  # noqa: E402
 
 pytest_plugins = ["tests.test_api"]
 
@@ -43,8 +43,6 @@ async def test_export_import_roundtrip(async_client):
             "adpf": 8.0,
             "density": 7.0,
             "is_dangerous": True,
-            "plast_fam": "PET",
-            "mara_plast_id": 42,
         },
         headers=headers,
     )
@@ -78,8 +76,6 @@ async def test_export_import_roundtrip(async_client):
     assert "biogenic_gwp" in reader.fieldnames
     assert "adpf" in reader.fieldnames
     assert "is_dangerous" in reader.fieldnames
-    assert "plast_fam" in reader.fieldnames
-    assert "mara_plast_id" in reader.fieldnames
     assert "volume" in reader.fieldnames
     assert "density" in reader.fieldnames
     assert "weight" in reader.fieldnames
@@ -91,8 +87,6 @@ async def test_export_import_roundtrip(async_client):
     assert rows[0]["adpf"] == "8.0"
     assert rows[0]["density"] == "7.0"
     assert rows[0]["is_dangerous"] == "True"
-    assert rows[0]["plast_fam"] == "PET"
-    assert rows[0]["mara_plast_id"] == "42"
     sus_row = next(r for r in rows if r["model"] == "sustainability")
     assert sus_row["component_id"] == str(component_id)
     assert float(sus_row["score"]) == 0.0
@@ -105,7 +99,8 @@ async def test_export_import_roundtrip(async_client):
     with engine2.connect() as conn:
         conn.execute(
             text(
-                "CREATE TABLE materials (id INTEGER PRIMARY KEY, name VARCHAR, description VARCHAR)"
+                "CREATE TABLE materials (id INTEGER PRIMARY KEY, "
+                "name VARCHAR, description VARCHAR)"
             )
         )
     TestingSessionLocal = sessionmaker(
@@ -153,8 +148,6 @@ async def test_export_import_roundtrip(async_client):
         assert mat["adpf"] == 8.0
         assert mat["density"] == 7.0
         assert mat["is_dangerous"] is True
-        assert mat["plast_fam"] == "PET"
-        assert mat["mara_plast_id"] == 42
         resp = await ac.get(
             "/components",
             params={"project_id": project_id},

--- a/tests/test_recycle.py
+++ b/tests/test_recycle.py
@@ -1,0 +1,90 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+pytest_plugins = ["tests.test_api"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_recycle_evaluation(async_client_full_schema):
+    client = async_client_full_schema
+    login = await client.post(
+        "/token", data={"username": "admin", "password": "secret"}
+    )
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    proj = await client.post(
+        "/projects",
+        json={"name": "Proj", "r_strategies": ["R8"]},
+        headers=headers,
+    )
+    project_id = proj.json()["id"]
+
+    mat1 = await client.post(
+        "/materials",
+        json={
+            "name": "Mat1",
+            "project_id": project_id,
+            "density": 1.0,
+        },
+        headers=headers,
+    )
+    mat2 = await client.post(
+        "/materials",
+        json={
+            "name": "Mat2",
+            "project_id": project_id,
+            "density": 1.0,
+        },
+        headers=headers,
+    )
+    mat1_id = mat1.json()["id"]
+    mat2_id = mat2.json()["id"]
+
+    root = await client.post(
+        "/components",
+        json={
+            "name": "Root",
+            "project_id": project_id,
+            "material_id": mat1_id,
+            "level": 0,
+            "volume": 2.0,
+            "systemability": 1.0,
+            "r_factor": 1.0,
+            "trenn_eff": 1.0,
+            "sort_eff": 1.0,
+            "mv_bonus": 0.0,
+            "mv_abzug": 0.0,
+        },
+        headers=headers,
+    )
+    root_id = root.json()["id"]
+
+    await client.post(
+        "/components",
+        json={
+            "name": "Child",
+            "project_id": project_id,
+            "material_id": mat2_id,
+            "parent_id": root_id,
+            "level": 1,
+            "volume": 1.0,
+            "r_factor": 0.9,
+            "trenn_eff": 0.95,
+            "sort_eff": 0.95,
+        },
+        headers=headers,
+    )
+
+    resp = await client.post(
+        f"/recycle/{project_id}", headers=headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["recycle_value"] == pytest.approx(0.935, rel=1e-2)
+    assert data["grade"] == "B"


### PR DESCRIPTION
## Summary
- allow projects to store selected R-strategies
- support Recycle strategy with detailed component fields and evaluation endpoint
- remove obsolete plastic family fields and extend export/import
- add tests for recycle evaluation

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c99b17e70833280ecd07993cb80a7