### PR TITLE
Improve component forms and finish flow

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -337,6 +337,10 @@ def compute_component_score(
         f2 = sum(child_scores)
         f3 = 0.9 if component.reusable else 1.0
         level = component.connection_type or 0
+        try:
+            level = float(level)
+        except (TypeError, ValueError):
+            level = 0
         bounded = min(max(level, 0), 5)
         f4 = 1.0 - 0.05 * bounded
     score = f1 * f2 * f3 * f4


### PR DESCRIPTION
## Summary
- Remove modal usage and show dialog confirmation when finalizing a product
- Filter parent dropdown by level and refresh component hierarchy after create or update
- Show recycling-related inputs only when the project includes the R8 strategy
- Cast connection type to numeric before scoring to avoid type errors

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6d9f4973c8332a00831995e20106f