### PR TITLE
Remove connection type and gate material selection by atomic flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python -m uvicorn backend:app --reload
 ### Upgrade from previous versions
 
 Version 2.2 introduces several global warming potential columns on the `materials` table: `total_gwp`, `fossil_gwp`, `biogenic_gwp`, and `adpf`.
-Newer versions may also require additional columns on the `components` table, such as `connection_type`, `volume`, and `weight`.
+Newer versions may also require additional columns on the `components` table, such as `volume` and `weight`.
 If a legacy `density` column exists on `components`, it should be removed because component density is derived from the linked material.
 Because the example doesn't use a migration tool, you have two options when upgrading: delete the existing `app.db` file and let FastAPI recreate it on the next startup, or manually add the missing columns using `ALTER TABLE` statements. Without this step the API will fail to start with errors such as `no such column: materials.total_gwp`.
 
@@ -35,7 +35,6 @@ ALTER TABLE materials ADD COLUMN total_gwp FLOAT;
 ALTER TABLE materials ADD COLUMN fossil_gwp FLOAT;
 ALTER TABLE materials ADD COLUMN biogenic_gwp FLOAT;
 ALTER TABLE materials ADD COLUMN adpf FLOAT;
-ALTER TABLE components ADD COLUMN connection_type INTEGER;
 ALTER TABLE components ADD COLUMN volume FLOAT;
 ALTER TABLE components ADD COLUMN weight FLOAT;
 ALTER TABLE components DROP COLUMN density;

--- a/backend.py
+++ b/backend.py
@@ -111,7 +111,6 @@ class Component(Base):
     volume = Column(Float, nullable=True)
     weight = Column(Float, nullable=True)
     reusable = Column(Boolean, default=False)
-    connection_type = Column(Integer, nullable=True)
     systemability = Column(Float, nullable=True)
     r_factor = Column(Float, nullable=True)
     trenn_eff = Column(Float, nullable=True)
@@ -259,13 +258,12 @@ class MaterialRead(MaterialBase):
 
 class ComponentBase(BaseModel):
     name: str
-    material_id: int
+    material_id: Optional[int] = None
     level: Optional[int] = None
     parent_id: Optional[int] = None
     is_atomic: Optional[bool] = None
     volume: Optional[float] = None
     reusable: Optional[bool] = None
-    connection_type: Optional[int] = None
     systemability: Optional[float] = None
     r_factor: Optional[float] = None
     trenn_eff: Optional[float] = None
@@ -287,7 +285,6 @@ class ComponentUpdate(BaseModel):
     is_atomic: Optional[bool] = None
     volume: Optional[float] = None
     reusable: Optional[bool] = None
-    connection_type: Optional[int] = None
     systemability: Optional[float] = None
     r_factor: Optional[float] = None
     trenn_eff: Optional[float] = None
@@ -348,12 +345,7 @@ def compute_component_score(
         f1 = component.get_weight()
         f2 = sum(child_scores)
         f3 = 0.9 if component.reusable else 1.0
-        try:
-            level = int(component.connection_type)
-        except (TypeError, ValueError):
-            level = 0
-        bounded = min(max(level, 0), 5)
-        f4 = 1.0 - 0.05 * bounded
+        f4 = 1.0
     score = f1 * f2 * f3 * f4
 
     cache[component.id] = score
@@ -437,7 +429,6 @@ def on_startup():
             ("volume", "FLOAT"),
             ("weight", "FLOAT"),
             ("reusable", "BOOLEAN"),
-            ("connection_type", "INTEGER"),
             ("project_id", "INTEGER"),
             ("systemability", "FLOAT"),
             ("r_factor", "FLOAT"),
@@ -768,7 +759,6 @@ def export_csv(
         "volume",
         "weight",
         "reusable",
-        "connection_type",
         "systemability",
         "r_factor",
         "trenn_eff",
@@ -830,7 +820,6 @@ def export_csv(
                 comp.volume if comp.volume is not None else "",
                 comp.weight if comp.weight is not None else "",
                 comp.reusable if comp.reusable is not None else "",
-                comp.connection_type if comp.connection_type is not None else "",
                 comp.systemability if comp.systemability is not None else "",
                 comp.r_factor if comp.r_factor is not None else "",
                 comp.trenn_eff if comp.trenn_eff is not None else "",
@@ -860,7 +849,6 @@ def export_csv(
                 "",
                 "",
                 project_id,
-                "",
                 "",
                 "",
                 "",
@@ -938,11 +926,6 @@ async def import_csv(
                     volume=float(row["volume"]) if row.get("volume") else None,
                     weight=float(row["weight"]) if row.get("weight") else None,
                     reusable=row.get("reusable", "").lower() == "true",
-                    connection_type=(
-                        int(row["connection_type"])
-                        if row.get("connection_type")
-                        else None
-                    ),
                     systemability=(
                         float(row["systemability"])
                         if row.get("systemability")

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -25,13 +25,12 @@ def test_compute_component_score_hierarchy():
         volume=1.0,
         weight=2.0,
         reusable=False,
-        connection_type=1,
         material=mat,
     )
     root.children.append(child)
     child.parent = root
     score = compute_component_score(root)
-    assert pytest.approx(score) == 9.5
+    assert pytest.approx(score) == 10.0
 
 
 def test_compute_component_score_volume_density():
@@ -49,10 +48,9 @@ def test_compute_component_score_default_weight_non_atomic():
         name="root",
         is_atomic=False,
         reusable=False,
-        connection_type=1,
         material=mat,
     )
     root.children.append(child)
     child.parent = root
     score = compute_component_score(root)
-    assert pytest.approx(score) == 4.75
+    assert pytest.approx(score) == 5.0


### PR DESCRIPTION
## Summary
- Hide material selector for non-atomic components and only submit material when atomic
- Remove obsolete connection type field from models, computation, export and UI
- Adjust documentation and tests for new component behaviour

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b823de37508332a5316f4972a8cbd6