### PR TITLE
Remove obsolete connection type field

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python -m uvicorn backend:app --reload
 ### Upgrade from previous versions
 
 Version 2.2 introduces several global warming potential columns on the `materials` table: `total_gwp`, `fossil_gwp`, `biogenic_gwp`, and `adpf`.
-Newer versions may also require additional columns on the `components` table, such as `connection_type`, `volume`, and `weight`.
+Newer versions may also require additional columns on the `components` table, such as `volume` and `weight`.
 If a legacy `density` column exists on `components`, it should be removed because component density is derived from the linked material.
 Because the example doesn't use a migration tool, you have two options when upgrading: delete the existing `app.db` file and let FastAPI recreate it on the next startup, or manually add the missing columns using `ALTER TABLE` statements. Without this step the API will fail to start with errors such as `no such column: materials.total_gwp`.
 
@@ -35,7 +35,6 @@ ALTER TABLE materials ADD COLUMN total_gwp FLOAT;
 ALTER TABLE materials ADD COLUMN fossil_gwp FLOAT;
 ALTER TABLE materials ADD COLUMN biogenic_gwp FLOAT;
 ALTER TABLE materials ADD COLUMN adpf FLOAT;
-ALTER TABLE components ADD COLUMN connection_type INTEGER;
 ALTER TABLE components ADD COLUMN volume FLOAT;
 ALTER TABLE components ADD COLUMN weight FLOAT;
 ALTER TABLE components DROP COLUMN density;

--- a/frontend.py
+++ b/frontend.py
@@ -310,7 +310,6 @@ elif page == "Components":
                 "is_atomic",
                 "volume",
                 "reusable",
-                "connection_type",
                 "systemability",
                 "r_factor",
                 "trenn_eff",
@@ -361,7 +360,6 @@ elif page == "Components":
         is_atomic = st.checkbox("Atomic")
         volume = st.number_input("Volume", value=0.0)
         reusable = st.checkbox("Reusable")
-        connection_type = st.number_input("Connection type", value=0, step=1)
 
         systemability = None
         r_factor = None
@@ -450,7 +448,6 @@ elif page == "Components":
                     "is_atomic": is_atomic,
                     "volume": volume,
                     "reusable": reusable,
-                    "connection_type": connection_type,
                     **(
                         {
                             "systemability": systemability,
@@ -547,11 +544,6 @@ elif page == "Components":
                 "Reusable",
                 value=comp.get("reusable", False),
             )
-            up_conn = st.number_input(
-                "Connection type",
-                value=comp.get("connection_type", 0) or 0,
-                step=1,
-            )
             up_systemability = comp.get("systemability")
             up_r_factor = comp.get("r_factor")
             up_trenn_eff = comp.get("trenn_eff")
@@ -626,7 +618,11 @@ elif page == "Components":
                     else 0
                 )
                 up_sort_eff = sort_map[
-                    st.selectbox("Sorting efficiency", list(sort_map.keys()), index=sort_idx)
+                    st.selectbox(
+                        "Sorting efficiency",
+                        list(sort_map.keys()),
+                        index=sort_idx,
+                    )
                 ]
                 mv_bonus_map = {
                     "None": 0.0,
@@ -679,7 +675,6 @@ elif page == "Components":
                         "is_atomic": up_atomic,
                         "volume": up_volume,
                         "reusable": up_reusable,
-                        "connection_type": up_conn,
                         **(
                             {
                                 "systemability": up_systemability,

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -25,13 +25,12 @@ def test_compute_component_score_hierarchy():
         volume=1.0,
         weight=2.0,
         reusable=False,
-        connection_type=1,
         material=mat,
     )
     root.children.append(child)
     child.parent = root
     score = compute_component_score(root)
-    assert pytest.approx(score) == 9.5
+    assert pytest.approx(score) == 10.0
 
 
 def test_compute_component_score_volume_density():
@@ -49,10 +48,9 @@ def test_compute_component_score_default_weight_non_atomic():
         name="root",
         is_atomic=False,
         reusable=False,
-        connection_type=1,
         material=mat,
     )
     root.children.append(child)
     child.parent = root
     score = compute_component_score(root)
-    assert pytest.approx(score) == 4.75
+    assert pytest.approx(score) == 5.0


### PR DESCRIPTION
## Summary
- drop `connection_type` from component model and related logic
- remove connection type inputs in Streamlit UI
- adjust tests and docs for simplified scoring

## Testing
- `flake8 && echo flake8-ok`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log && echo pytest-ok`


------
https://chatgpt.com/codex/tasks/task_e_68b829b244208332868fd4c57239d9a2