### PR TITLE
Fix payload mapping error for component creation

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -487,7 +487,7 @@ elif page == "Components":
                             "mv_abzug": mv_abzug,
                         }
                         if "R8" in r_strats
-                        else {},
+                        else {}
                     ),
                 }
                 if is_atomic:


### PR DESCRIPTION
## Summary
- avoid tuple expansion when assembling component payloads

## Testing
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b86728973c83328391cab2a0f3be53