### PR TITLE
Cache Graphviz rendering on demand

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -78,8 +78,9 @@ def get_projects():
         return []
 
 
-def build_graphviz_tree(items):
-    dot = Digraph()
+@st.cache_data(ttl=30, show_spinner=False)
+def build_graphviz_source(items):
+    dot = Digraph(engine="dot")
     for comp in items:
         label = f"{comp['name']}\nLevel {comp.get('level', '')}"
         dot.node(str(comp['id']), label)
@@ -87,7 +88,7 @@ def build_graphviz_tree(items):
         parent = comp.get('parent_id')
         if parent:
             dot.edge(str(parent), str(comp['id']))
-    return dot
+    return dot.source
 
 
 auth_token = st.session_state.get("token")
@@ -795,7 +796,9 @@ elif page == "Components":
             rerun()
 
     st.header("Component hierarchy")
-    st.graphviz_chart(build_graphviz_tree(components))
+    with st.expander("Component hierarchy (Graph)"):
+        src = build_graphviz_source(components)
+        st.graphviz_chart(src, use_container_width=True)
     tree = build_tree(components)
     display_tree(tree)
 

--- a/tests/test_graphviz.py
+++ b/tests/test_graphviz.py
@@ -1,13 +1,12 @@
 import frontend
 
 
-def test_build_graphviz_tree():
+def test_build_graphviz_source():
     components = [
         {"id": 1, "name": "Root", "level": 0, "parent_id": None},
         {"id": 2, "name": "Child", "level": 1, "parent_id": 1},
     ]
-    dot = frontend.build_graphviz_tree(components)
-    src = dot.source
+    src = frontend.build_graphviz_source(components)
     assert '1 [label="Root' in src
     assert '2 [label="Child' in src
     assert '1 -> 2' in src


### PR DESCRIPTION
## Summary
- add cached `build_graphviz_source` to avoid rebuilding Graphviz data
- display component graph only when expander is opened
- adjust Graphviz test to use new helper

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b95509771883329c20be9b5f1280b2