### PR TITLE
Add home page option and auth helper to frontend

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -5,6 +5,12 @@ from graphviz import Digraph
 import requests
 
 
+def require_auth():
+    if "token" not in st.session_state:
+        st.session_state["page_select"] = "Home"
+        st.rerun()
+
+
 def do_rerun():
     """Compatibility helper for Streamlit rerun."""
     if hasattr(st, "experimental_rerun"):
@@ -169,9 +175,14 @@ else:
 
 
 st.title("DIMOP 2.2")
+page_options = ["Home", "Materials", "Components", "Export/Import"]
+default_idx = (
+    page_options.index(st.session_state.get("page_select", "Home"))
+    if st.session_state.get("page_select", "Home") in page_options
+    else 0
+)
 page = st.sidebar.selectbox(
-    "Page",
-    ["Materials", "Components", "Export/Import"],
+    "Page", page_options, index=default_idx, key="page_select"
 )
 
 if page == "Materials":


### PR DESCRIPTION
## Summary
- Add `require_auth` helper to redirect unauthenticated users to Home
- Replace sidebar page selector with configurable options including new Home entry and session-state tracking

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b95ba9abac8332b7ee11e5c98b276f