### PR TITLE
Display R tags in project overview and update button colors

### DIFF
--- a/frontend.py
+++ b/frontend.py
@@ -209,15 +209,27 @@ def render_projects():
                         -webkit-box-orient:vertical;
                         font-weight:600;
                         font-size:1.1rem;
-                        line-height:1.2;">{proj['name']}</div>
+                        line-height:1.2;
+                        margin-bottom:2px;">{proj['name']}</div>
                     """,
+                    unsafe_allow_html=True,
+                )
+                codes = proj.get("r_strategies") or []
+                labels = [LABELS.get(c, c) for c in codes]
+                tags_html = " ".join(
+                    f"<span style='padding:2px 6px;border:1px solid #ccc;"
+                    f"border-radius:8px;font-size:12px;margin-right:4px'>{lbl}</span>"
+                    for lbl in labels
+                )
+                st.markdown(
+                    f"<div style='height:72px;margin:2px 0 6px 0;overflow:hidden'>{tags_html}</div>",
                     unsafe_allow_html=True,
                 )
                 if st.button("Select", key=f"proj_select_{proj['id']}", use_container_width=True):
                     st.session_state["project_id"] = proj["id"]
                     st.session_state["r_strategies"] = proj.get("r_strategies") or []
                     navigate("Components")  # jump to Components when selecting a Project
-                st.write("")
+                st.markdown("<div style='height:4px'></div>", unsafe_allow_html=True)
                 if st.button(
                     "Delete", key=f"proj_delete_{proj['id']}", use_container_width=True
                 ):
@@ -247,8 +259,12 @@ def render_projects():
         });
         </script>
         <style>
-        .btn-select:hover { background-color: #00B050 !important; }
-        .btn-delete:hover { background-color: #FF0000 !important; }
+        .btn-select:hover,
+        .btn-select:active,
+        .btn-select:focus { background-color: #00B050 !important; }
+        .btn-delete:hover,
+        .btn-delete:active,
+        .btn-delete:focus { background-color: #FF0000 !important; }
         .btn-create:hover { filter: brightness(1.05); }
         </style>
         """,


### PR DESCRIPTION
## Summary
- Show selected R-strategy tags on each project tile
- Style Select buttons to use green hover/active/focus state while keeping Delete buttons red
- Allow up to three rows of tags and tighten tile spacing between project name, tags, and action buttons

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bad808a77c833298f502a6bdfae7eb